### PR TITLE
render markdown in user description

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "animate.css": "^3.5.2",
     "changeset-map": "1.0.8",
+    "commonmark-react-renderer": "^4.3.3",
     "date-input-polyfill": "^2.14.0",
     "history": "^4.6.3",
     "immutable": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "animate.css": "^3.5.2",
     "changeset-map": "1.0.8",
-    "commonmark-react-renderer": "^4.3.3",
     "date-input-polyfill": "^2.14.0",
     "history": "^4.6.3",
     "immutable": "^3.8.1",

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -377,3 +377,6 @@ img {
 .user-description a {
   color: #448ee4;
 }
+.user-description h2 {
+  font-weight: 600;
+}

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -373,3 +373,7 @@ img {
   height: 144px !important;
   width: 144px !important;
 }
+
+.user-description a {
+  color: #448ee4;
+}

--- a/src/components/changeset/user.js
+++ b/src/components/changeset/user.js
@@ -3,15 +3,13 @@ import { Avatar } from '../avatar';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { getObjAsQueryParam } from '../../utils/query_params';
-import CommonMark from 'commonmark';
-import ReactRenderer from 'commonmark-react-renderer';
+import showdown from 'showdown';
 
 // getObjAsQueryParam('filters', filters.toJS());
 export function User({ userDetails, whosThat }) {
-  var parser = new CommonMark.Parser();
-  var renderer = new ReactRenderer();
-  const UserDescriptionHTML = renderer.render(
-    parser.parse(userDetails.get('description') || '')
+  const converter = new showdown.Converter({ noHeaderId: true });
+  const UserDescriptionHTML = converter.makeHtml(
+    userDetails.get('description') || ''
   );
 
   return (
@@ -86,9 +84,10 @@ export function User({ userDetails, whosThat }) {
             )}
           </div>}
         <div className="mt12">
-          <p className="txt-subhead txt-s txt-break-url user-description">
-            {UserDescriptionHTML}
-          </p>
+          <p
+            className="txt-subhead txt-s txt-break-url user-description"
+            dangerouslySetInnerHTML={{ __html: UserDescriptionHTML }}
+          />
         </div>
       </div>
     </div>

--- a/src/components/changeset/user.js
+++ b/src/components/changeset/user.js
@@ -7,7 +7,10 @@ import showdown from 'showdown';
 
 // getObjAsQueryParam('filters', filters.toJS());
 export function User({ userDetails, whosThat }) {
-  const converter = new showdown.Converter({ noHeaderId: true });
+  const converter = new showdown.Converter({
+    noHeaderId: true,
+    simplifiedAutoLink: true
+  });
   const UserDescriptionHTML = converter.makeHtml(
     userDetails.get('description') || ''
   );

--- a/src/components/changeset/user.js
+++ b/src/components/changeset/user.js
@@ -1,14 +1,19 @@
 import React from 'react';
 import { Avatar } from '../avatar';
 import moment from 'moment';
-import AnchorifyText from 'react-anchorify-text';
-import { Button } from '../button';
-import AssemblyAnchor from '../assembly_anchor';
 import { Link } from 'react-router-dom';
 import { getObjAsQueryParam } from '../../utils/query_params';
+import CommonMark from 'commonmark';
+import ReactRenderer from 'commonmark-react-renderer';
 
 // getObjAsQueryParam('filters', filters.toJS());
 export function User({ userDetails, whosThat }) {
+  var parser = new CommonMark.Parser();
+  var renderer = new ReactRenderer();
+  const UserDescriptionHTML = renderer.render(
+    parser.parse(userDetails.get('description') || '')
+  );
+
   return (
     <div className="px12 py6">
       <h2 className="txt-m txt-uppercase txt-bold mr6 mb3">
@@ -81,10 +86,8 @@ export function User({ userDetails, whosThat }) {
             )}
           </div>}
         <div className="mt12">
-          <p className="txt-subhead txt-s txt-break-url">
-            <AnchorifyText text={userDetails.get('description') || ''}>
-              <AssemblyAnchor />
-            </AnchorifyText>
+          <p className="txt-subhead txt-s txt-break-url user-description">
+            {UserDescriptionHTML}
           </p>
         </div>
       </div>


### PR DESCRIPTION
![captura de tela de 2017-08-25 17-55-58](https://user-images.githubusercontent.com/666291/29732520-4d9e3c6e-89bf-11e7-9d62-697f37bfb05e.png)

I would like to disallow images to be rendered. I tested to add {disallowedTypes: ['Image']} to the markdown renderer, but it didn't work.