### PR TITLE
modify save filter behavior and design + allow to update an aoi

### DIFF
--- a/src/components/filters/filters_header.js
+++ b/src/components/filters/filters_header.js
@@ -8,7 +8,7 @@ import { Dropdown } from '../dropdown';
 import { AOIManager } from './aoi_manager';
 import { isProd } from '../../config';
 
-class AOIName extends React.PureComponent {
+class SaveAOI extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -39,28 +39,43 @@ class AOIName extends React.PureComponent {
       this.clicked = false;
     }
   };
+  handleSubmit = event => {
+    this.setState({
+      editing: false
+    });
+    if (this.props.aoiId) {
+      this.props.updateAOI(this.props.aoiId, this.state.value);
+    } else {
+      this.props.createAOI(this.state.value);
+      event.preventDefault();
+    }
+  };
   // handleFocus = event => {
   //   event.target.select();
   // };
   render() {
     return (
       <span>
-        /
         {this.state.editing
-          ? <input
-              ref={r => {
-                if (this.clicked) {
-                  r.select();
-                  this.clicked = false;
-                }
-              }}
-              value={this.state.value}
-              onChange={this.onChange}
-              onKeyDown={this.onKeyDown}
-            />
-          : <span onClick={this.onClick}>
-              {this.props.name}
-            </span>}
+          ? <span>
+              <input
+                ref={r => {
+                  if (this.clicked) {
+                    r.select();
+                    this.clicked = false;
+                  }
+                }}
+                value={this.state.value}
+                onChange={this.onChange}
+                onKeyDown={this.onKeyDown}
+              />
+              <Button onClick={this.handleSubmit} className="mx3">
+                Confirm Save
+              </Button>
+            </span>
+          : <Button onClick={this.onClick} className="border--0 bg-transparent">
+              Save
+            </Button>}
       </span>
     );
   }
@@ -71,18 +86,22 @@ export function FiltersHeader({
   search,
   token,
   aoiName,
+  aoiId,
   createAOI,
+  updateAOI,
   removeAOI,
   handleApply,
   handleClear,
   loadAoiId
 }: {
   createAOI: string => void,
+  updateAOI: string => void,
   removeAOI: string => void,
   loading: boolean,
   search: string,
   token?: string,
   aoiName?: string,
+  aoiId?: string,
   handleApply: () => void,
   handleClear: () => void,
   loadAoiId: string => void
@@ -90,10 +109,16 @@ export function FiltersHeader({
   return (
     <header className="h55 hmin55 flex-parent px30 bg-gray-faint flex-parent--center-cross justify--space-between color-gray border-b border--gray-light border--1">
       <span className="txt-l txt-bold color-gray--dark">
-        <span>Filters</span>
-        {aoiName && <AOIName name={aoiName} createAOI={createAOI} />}
+        <span>Filters/</span>
+        {aoiName}
       </span>
       <span className="txt-l color-gray--dark">
+        <SaveAOI
+          name={aoiName}
+          aoiId={aoiId}
+          createAOI={createAOI}
+          updateAOI={updateAOI}
+        />
         <Button className="border--0 bg-transparent" onClick={handleClear}>
           Reset
         </Button>

--- a/src/components/filters/filters_header.js
+++ b/src/components/filters/filters_header.js
@@ -27,10 +27,7 @@ class SaveAOI extends React.PureComponent {
   };
   onKeyDown = event => {
     if (event.keyCode === 13) {
-      this.setState({
-        editing: false
-      });
-      this.props.createAOI(this.state.value);
+      this.handleSubmit(event);
     } else if (event.keyCode === 27) {
       this.setState({
         editing: false,
@@ -47,7 +44,6 @@ class SaveAOI extends React.PureComponent {
       this.props.updateAOI(this.props.aoiId, this.state.value);
     } else {
       this.props.createAOI(this.state.value);
-      event.preventDefault();
     }
   };
   // handleFocus = event => {

--- a/src/network/aoi.js
+++ b/src/network/aoi.js
@@ -79,15 +79,24 @@ export function updateAOI(
   name: string,
   filters: string
 ): Promise<*> {
+  let serverFilters = {};
+  filters.forEach((v: filterType, k: string) => {
+    if (!Iterable.isIterable(v)) return;
+    let filter = v;
+    serverFilters[k] = filter
+      .filter(x => Iterable.isIterable(x) && x.get('value') !== '')
+      .map(x => x.get('value'))
+      .join(',');
+  });
   return fetch(`${API_URL}/aoi/${aoiId}/`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: token ? `Token ${token}` : ''
     },
-    body: createForm({
+    body: JSON.stringify({
       name,
-      filters
+      filters: serverFilters
     })
   })
     .then(handleErrors)


### PR DESCRIPTION
I made some changes related to what I proposed in https://github.com/mapbox/osmcha-frontend/issues/167

![osm changeset analyzer 1](https://user-images.githubusercontent.com/666291/30434863-aaadade8-993e-11e7-88a4-af8d3ba54a43.png)

It has some bugs yet... I would be happy if someone can help:
- [ ] when you load a saved filter, it's name is exhibited correctly, but, in the save form input, the name is empty. If you click on the `X` to close the filter and click on the `Filter` button, and finally in the `Save`, it will load the name correctly.
![osm changeset analyzer](https://user-images.githubusercontent.com/666291/30434256-291a7622-993d-11e7-8c62-e54118294e46.png)

- [ ] After updating a filter, the request is sent and the update occurs perfectly in the backend, but the frontend reload the page to the state before the update (load a filter, modify and save it to reproduce. If you press F5 you will see that the filter was updated).