### PR TITLE
Always call JOSM over http

### DIFF
--- a/src/components/changeset/open_in.js
+++ b/src/components/changeset/open_in.js
@@ -12,7 +12,7 @@ export function OpenIn({ changesetId, coordinates, className }) {
           {
             label: 'JOSM',
             value: 'JOSM',
-            href: `https://127.0.0.1:8112/import?url=https://www.openstreetmap.org/api/0.6/changeset/${changesetId}/download`
+            href: `http://127.0.0.1:8111/import?url=https://www.openstreetmap.org/api/0.6/changeset/${changesetId}/download`
           },
           {
             label: 'iD',


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

https://github.com/w3c/webappsec-mixed-content/commit/349501cdaa4b4dc1e2a8aacb216ced58fd316165
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.