### PR TITLE
Add meta tag to prevent google translate

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="google" value="notranslate">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
   <link rel="preconnect" href="https://osmcha-django-staging.tilestream.net">
   <title>OSM Changeset Analyzer</title>


### PR DESCRIPTION
This should prevent google translate to randomly pop up without being actually visible on mobile. This should not influence the translate button which links to google translate externally https://github.com/h5bp/html5-boilerplate/commit/6d10fc8ccecbcfedbc743d7431688562cd6ae47a#diff-65730bf0f1b9dc6e703f19456334bd0fR567

# Example of the issue

- I open https://osmcha.mapbox.com/changesets/74764009/ from the rss feed inside a iOS integrated browser (iOS in German)
- I tab and touble tab the map a bit to reach some elements
  - It might be, that is only happens on the to left area of the screen, but I did not evaluate this enough
- Suddenly and without seeing a translate-UI first, the google translate UI loads for strings like https://translate.google.com/#auto/en/siehe%20Änderungssatz%3A%2074722824

![IMG_A6A1E26A3754-1](https://user-images.githubusercontent.com/111561/65383793-a8a84900-dd1a-11e9-932c-2b134820b124.jpeg)
