### PR TITLE
Always call JOSM over http

### DIFF
--- a/src/views/navbar_changeset.js
+++ b/src/views/navbar_changeset.js
@@ -69,7 +69,7 @@ class NavbarChangeset extends React.PureComponent<void, propsType, *> {
       }
       case OPEN_IN_JOSM.label: {
         if (!this.props.changesetId) return;
-        const url = `https://127.0.0.1:8112/import?url=https://www.openstreetmap.org/api/0.6/changeset/${
+        const url = `http://127.0.0.1:8111/import?url=https://www.openstreetmap.org/api/0.6/changeset/${
           this.props.changesetId
         }/download`;
         window.open(url, '_blank');


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

w3c/webappsec-mixed-content@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.