### PR TITLE
Update broken links in About doc

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -432,14 +432,13 @@ This is raised when someone tries to remove tags in a changeset that are added b
 
 # Other tools for validation
 
-* [OSM-Comments](https://www.mapbox.com/osm-comments/)
-* [MapRoulette](http://www.maproulette.org/)
+* [MapRoulette](https://maproulette.org/)
 * [HDYC](https://hdyc.neis-one.org/)
 * [WHODIDIT](http://simon04.dev.openstreetmap.org/whodidit/)
 * [Who’s That](http://whosthat.osmz.ru)
 * [Result Maps](http://resultmaps.neis-one.org/)
 * [Missing Maps](https://www.missingmaps.org/users/)
-* [Live OSM user stats](http://www.gryph.de:8080/)
+* [OSM user stats](https://www.openstreetmap.org/stats/data_stats.html)
 * [OSM deep history](https://osmlab.github.io/osm-deep-history)
 * [OSM History viewer](http://osmhv.openstreetmap.de/index.jsp)
 * [OSM inspector](https://tools.geofabrik.de/osmi/)


### PR DESCRIPTION
Under the section of `Other tools for validation`, updated broken links and removed reference to OSM comments API (now deprecated). 