### PR TITLE
Fix failing tests

### DIFF
--- a/src/views/teams.js
+++ b/src/views/teams.js
@@ -152,7 +152,7 @@ class SaveButton extends React.PureComponent {
             />
             <span className="txt-bold txt-truncate pt6">Users</span>
             <textarea
-              placeholder={`[{"username": "name"}, {"username": "other_user"}]`}
+              placeholder={'[{"username": "name"}, {"username": "other_user"}]'}
               className="textarea h180"
               ref={r => {
                 if (this.clicked) {


### PR DESCRIPTION
The tests seem to be failing. More specifically, `yarn test` was failing with this error:

```
/osmcha-frontend/src/views/teams.js
  155:28  error  Strings must use singlequote  quotes

✖ 33 problems (1 error, 32 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.

npm ERR! code ELIFECYCLE
```

With this change, the tests are no longer failing.