### PR TITLE
feat(multi_select): introduce osm-teams feature flag

### DIFF
--- a/src/components/filters/multi_select.js
+++ b/src/components/filters/multi_select.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { fromJS } from 'immutable';
 import { Creatable, Async } from 'react-select';
-import { API_URL } from '../../config';
+import { API_URL, OSM_TEAMS_API_URL, isOsmTeamsEnabled } from '../../config';
 import type { filterType } from './';
 
 export class MultiSelect extends React.PureComponent {
@@ -130,10 +130,14 @@ export class MultiSelect extends React.PureComponent {
 export class MappingTeamMultiSelect extends MultiSelect {
   getAsyncOptions = () => {
     if (!this.props.dataURL) return;
-    return fetch(`${API_URL}/${this.props.dataURL}/`, {
+    const url = isOsmTeamsEnabled
+      ? OSM_TEAMS_API_URL
+      : `${API_URL}/${this.props.dataURL}/`;
+    return fetch(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        // TODO: the OSM Teams endpoint doesn't require auth (yet)
         Authorization: this.props.token ? `Token ${this.props.token}` : ''
       }
     })

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,6 +4,7 @@ export const isStaging = process.env.REACT_APP_STACK === 'STAGING';
 export const isProd = process.env.REACT_APP_STACK === 'PRODUCTION';
 export const isLocal = process.env.NODE_ENV === 'development';
 export const stack = process.env.REACT_APP_STACK;
+export const isOsmTeamsEnabled = true;
 export const appVersion = process.env.REACT_APP_VERSION;
 
 let url = 'https://osmcha-django-staging.tilestream.net/api/v1';
@@ -17,3 +18,4 @@ window.debug_info = () =>
     'null'} appVersion=${appVersion || 'null'} url=${url}`;
 
 export const API_URL = url;
+export const OSM_TEAMS_API_URL = 'https://dev.mapping.team/api/teams';


### PR DESCRIPTION
**WIP**

TODO's:
  - [ ] refactor feature flag as an environmental variable, and making it configurable via npm script, eg `yarn run osm-teams`
  - [ ] transform the data the comes back from osm-teams endpoint to match the existing OSMCha model so that the filters are actually working
