### PR TITLE
Use user preference for opening new layers in JOSM

### DIFF
--- a/src/components/changeset/features.js
+++ b/src/components/changeset/features.js
@@ -46,7 +46,7 @@ const Feature = ({
         <span className="cursor-pointer txt-bold txt-underline-on-hover">
           <a
             target="_blank"
-            href={`https://localhost:8112/load_object?new_layer=true&objects=${data
+            href={`https://localhost:8112/load_object?objects=${data
               .getIn(['url'], '')
               .charAt(0)}${data.get('osm_id')}`}
           >


### PR DESCRIPTION
JOSM allows user to set whether they would like remote control to create new layers or not in preferences. 
In OSMCha, by specifying `new_layer=true` in the remote control URL, the user preference is bypassed.

I think it would be best to use the default set in JOSM. Another solution would be provide two remote control links, one creating a new layer, one which does not.