### PR TITLE
Add generic error message to about.md

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -385,6 +385,16 @@ No, you cannot review your own changesets, but you can view your changesets.
 
 ## Changeset views error messages
 
+### Authentication error. Sign in again and repeat the operation.
+
+This is the default error message whenever you try to do something that is not possible.
+
+For example:
+- When you try to check a changeset, that was already checked.
+- When you try to check our own changeset.
+- When you try to uncheck a changeset, which was not checked by you.
+- When you try to tag a changeset or remove tags from a changeset, that was not checked by you.
+
 ### Changeset was already checked.
 
 This is raised when someone tries to check a changeset that was already checked


### PR DESCRIPTION
This error message is the only one I actually see. And it seems to show for all those cases.

I am not sure, if the other error messages that are documented below actually still exist. If not, they could be deleted from the documentation. If yes, I wonder how one would get to see them.