### PR TITLE
Make buttion "Open with -> iD" opens with iD in all cases

### DIFF
--- a/src/components/changeset/open_in.js
+++ b/src/components/changeset/open_in.js
@@ -17,7 +17,7 @@ export function OpenIn({ changesetId, coordinates, className }) {
           {
             label: 'iD',
             value: 'iD',
-            href: `https://www.openstreetmap.org/edit?changeset=${changesetId}#map=15/${coordinates &&
+            href: `https://www.openstreetmap.org/edit?editor=id&changeset=${changesetId}#map=15/${coordinates &&
               coordinates.get('1')}/${coordinates && coordinates.get('0')}`
           },
           {


### PR DESCRIPTION
In the case someone setup "Modify" button in web interface to open
something different than iD (JOSM, …) "Open with -> id" would not open
iD.

Passing editor=id parameter to url forces to actually use iD editor.