### PR TITLE
Login on dev simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository uses [prettier](https://github.com/prettier/prettier) to keep th
 
 ### Local development
 1. `yarn start`
-1. Open [https://localhost:3000/?filters={%22date__gte%22%3A[{%22label%22%3A%222017-05-01%22%2C%22value%22%3A%222017-05-01%22}]}](https://localhost:3000/?filters={%22date__gte%22%3A[{%22label%22%3A%222017-05-01%22%2C%22value%22%3A%222017-05-01%22}]})
+1. Open [https://localhost:3000/?filters={%22date__gte%22%3A[{%22label%22%3A%222017-05-01%22%2C%22value%22%3A%222017-05-01%22}]}](https://localhost:3000/?filters={%22date__gte%22%3A[{%22label%22%3A%222017-05-01%22%2C%22value%22%3A%222017-05-01%22}]}) of e.g. [changeset#68901012](https://localhost:3000/changesets/68901012?filters={%22date__gte%22%3A[{%22label%22%3A%222017-05-01%22%2C%22value%22%3A%222017-05-01%22}]})
     - The app runs with https; Firefox is recommended since it allows self signed certificates.
     - The staging database only has changesets until mid 2017; without the filter you will not see any changesets.
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ This repository uses [prettier](https://github.com/prettier/prettier) to keep th
     - The app runs with https; Firefox is recommended since it allows self signed certificates.
     - The staging database only has changesets until mid 2017; without the filter you will not see any changesets.
 
-*To sign in:*
-
-1. After loading the page in your browser, inspect the request made to `social-auth/` and copy the `oauth_token`;
-1. In other browser tab, access `https://www.openstreetmap.org/oauth/authorize?oauth_token=<oauth_token>` and give authorization in the OpenStreetMap page that will load;
-1. You will be redirected to a blank page that has a `oauth_verifier` in the url. Copy the `oauth_verifier`;
-1. Click on the `Sign in` button on your local OSMCha instance, paste the `oauth_verifier` and you will be logged in.
-
 ### Local testing
 Test the application before commiting any changes. If you encounter any error make sure you have `watchman` installed. [Installation Guide](https://facebook.github.io/watchman/docs/install.html).
 

--- a/public/local-landing.html
+++ b/public/local-landing.html
@@ -2,7 +2,22 @@
 
 <html>
 
+<head>
+  <title>OSMCha: Manually sign in to OSM for local development</title>
+</head>
+
 <body>
+  <h1>Manually sign in to OSM for local development:</h1>
+  <ol>
+    <li>
+      <a href="#"
+        onClick="window.open('https://www.openstreetmap.org/oauth/authorize?oauth_token=' + window.location.hash.substring(1)); return false;">
+        Use this Link to start the Oauth-Login on osm.org
+      </a>
+    </li>
+    <li>Log into OSM on that page. You will see a blank page afterwards</li>
+    <li>Copy the value of the <code>oauth_verifier</code> param from the URL and paste it below</li>
+  </ol>
   <div id='formContainer'>
     <form id='verifierForm'>
       <input id='oauth_verifier' value='' placeholder='oauth_verifier' />

--- a/src/components/changeset/sign_in_button.js
+++ b/src/components/changeset/sign_in_button.js
@@ -24,10 +24,11 @@ class SignInButton extends React.PureComponent {
     var oAuthToken = this.props.oAuthToken;
     if (!oAuthToken) return;
 
+    let url;
     if (isDev || isLocal) {
-      let url = `/local-landing.html#${oAuthToken}`;
+      url = `/local-landing.html#${oAuthToken}`;
     } else {
-      let url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
+      url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
     }
 
     createPopup('oauth_popup', url);

--- a/src/components/changeset/sign_in_button.js
+++ b/src/components/changeset/sign_in_button.js
@@ -28,12 +28,10 @@ class SignInButton extends React.PureComponent {
       url = '/local-landing.html';
     }
 
-    if (oAuthToken) {
-      createPopup('oauth_popup', url);
-      handlePopupCallback().then(oAuthObj => {
-        this.props.getFinalToken(oAuthObj.oauth_verifier);
-      });
-    }
+    createPopup('oauth_popup', url);
+    handlePopupCallback().then(oAuthObj => {
+      this.props.getFinalToken(oAuthObj.oauth_verifier);
+    });
   };
   render() {
     const extraClasses = this.props.className

--- a/src/components/changeset/sign_in_button.js
+++ b/src/components/changeset/sign_in_button.js
@@ -23,9 +23,11 @@ class SignInButton extends React.PureComponent {
   handleLoginClick = () => {
     var oAuthToken = this.props.oAuthToken;
     if (!oAuthToken) return;
-    let url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
+
     if (isDev || isLocal) {
-      url = '/local-landing.html';
+      let url = `/local-landing.html#${oAuthToken}`;
+    } else {
+      let url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
     }
 
     createPopup('oauth_popup', url);

--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -48,12 +48,10 @@ class NavbarSidebar extends React.PureComponent {
       url = '/local-landing.html';
     }
 
-    if (oAuthToken) {
-      createPopup('oauth_popup', url);
-      handlePopupCallback().then(oAuthObj => {
-        this.props.getFinalToken(oAuthObj.oauth_verifier);
-      });
-    }
+    createPopup('oauth_popup', url);
+    handlePopupCallback().then(oAuthObj => {
+      this.props.getFinalToken(oAuthObj.oauth_verifier);
+    });
   };
   onUserMenuSelect = (arr: Array<Object>) => {
     if (arr.length === 1) {

--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -44,10 +44,11 @@ class NavbarSidebar extends React.PureComponent {
     var oAuthToken = this.props.oAuthToken;
     if (!oAuthToken) return;
 
+    let url;
     if (isDev || isLocal) {
-      let url = `/local-landing.html#${oAuthToken}`;
+      url = `/local-landing.html#${oAuthToken}`;
     } else {
-      let url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
+      url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
     }
 
     createPopup('oauth_popup', url);

--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -43,9 +43,11 @@ class NavbarSidebar extends React.PureComponent {
   handleLoginClick = () => {
     var oAuthToken = this.props.oAuthToken;
     if (!oAuthToken) return;
-    let url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
+
     if (isDev || isLocal) {
-      url = '/local-landing.html';
+      let url = `/local-landing.html#${oAuthToken}`;
+    } else {
+      let url = `${osmAuthUrl}?oauth_token=${oAuthToken}`;
     }
 
     createPopup('oauth_popup', url);


### PR DESCRIPTION
The main changes are:
- pass the oauth_token to the local-landing.html (as a hash, since this was easiest)
- extend the local-landing with the tutorial that was in the readme previously and provide a link that uses the given oauth_token
- cleanup readme, since the UI explains itself now

Also:
- remove a non-needed if-statement
- add a link to the readme