### PR TITLE
Redirect to non-www via JS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,10 @@
     if (location.protocol == 'http:') {
       location.href = location.href.replace(/^http:/, 'https:');
     }
+    // Redirect to non-WWW
+    if (window.location.hostname.indexOf("www") == 0) {
+      window.location = window.location.href.replace("www.", "");
+    }
 
     // Single Page Apps for GitHub Pages
     // https://github.com/rafrex/spa-github-pages


### PR DESCRIPTION
This is bad for SEO, but since SEO is not of our concern(*), we can just do the redirect in JS. This follows the pattern for the non-http-redirect right above.

(*) With Google Webmaster Tools it would also be possible to specify a primary domain to solve the duplicate content problem.

This solves https://github.com/mapbox/osmcha-frontend/issues/441

This script is based on https://stackoverflow.com/a/47281530