### PR TITLE
readme: hint that the deploy:dev does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn test
 
 ## Deploy/Release
 - There are three stacks to deploy to
-- `yarn deploy:dev` deploys it to `mapbox.github.io`
+- ~~`yarn deploy:dev` deploys it to `mapbox.github.io`~~ (currently broken)
 - `yarn deploy:staging` deploys it to `osmcha-django-staging.tilestream.net`
 - `yarn deploy:prod` deploys it to `osmcha.org`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yarn test
 ## Deploy/Release
 - There are three stacks to deploy to
 - ~~`yarn deploy:dev` deploys it to `mapbox.github.io`~~ (currently broken)
-- `yarn deploy:staging` deploys it to `osmcha-django-staging.tilestream.net`
+- `yarn deploy:staging` deploys it to `staging.osmcha.org`
 - `yarn deploy:prod` deploys it to `osmcha.org`
 
 1. Run the tests with `yarn test`


### PR DESCRIPTION
The given URL redirects to mapbox.com, so this is not working ATM. Since it seems to not be used ATM, we should at least hint that it is non-working for now. This is what this PR is about.

```console
$ http https://mapbox.github.io
HTTP/1.1 200 OK
Accept-Ranges: bytes
Access-Control-Allow-Origin: *
Age: 0
Cache-Control: max-age=600
Connection: keep-alive
Content-Length: 117
Content-Type: text/html; charset=utf-8
Date: Sat, 11 Apr 2020 06:09:50 GMT
ETag: "52e957f2-75"
Expires: Sat, 11 Apr 2020 06:19:50 GMT
Last-Modified: Wed, 29 Jan 2014 19:35:14 GMT
Server: GitHub.com
Vary: Accept-Encoding
Via: 1.1 varnish
X-Cache: MISS
X-Cache-Hits: 0
X-Fastly-Request-ID: 3e2512beb6b85f8088cd2c9f2531ca8eb97a09d6
X-GitHub-Request-Id: B6E2:2176:1015E7:149519:5E915F2D
X-Proxy-Cache: MISS
X-Served-By: cache-hhn4082-HHN
X-Timer: S1586585390.252592,VS0,VE92

<!DOCTYPE html>
<html>
<head>
  <meta http-equiv="refresh" content="0; url=https://www.mapbox.com/">
</head>
</html>

```