### PR TITLE
HTML Semantics, mainly <strong>-Tags

### DIFF
--- a/src/components/changeset/comment.js
+++ b/src/components/changeset/comment.js
@@ -85,16 +85,14 @@ export class CommentForm extends React.PureComponent<any, propsType, any> {
           <div className="flex-parent flex-parent--column mt6 mb3">
             {this.state.success && (
               <div className="bg-green-faint color-green inline-block px6 py3 txt-s align-center round my12">
-                <span className="txt-bold">Comment successfully posted.</span>
+                <strong>Comment successfully posted.</strong>
                 <br />
                 <span>It will appear on OSMCha after some minutes.</span>
               </div>
             )}
             {this.state.error && (
               <div className="bg-red-faint color-red-dark inline-block px6 py3 txt-s align-center round my12">
-                <span className="txt-bold">
-                  It was not possible to post your comment.
-                </span>
+                <strong>It was not possible to post your comment.</strong>
               </div>
             )}
             <div className="grid grid--gut12">

--- a/src/components/changeset/details.js
+++ b/src/components/changeset/details.js
@@ -65,8 +65,8 @@ export function Details({
       </div>
       <div className="flex-parent flex-parent--row justify--space-between flex-parent--wrap pt12 pb6">
         <div className="flex-parent flex-parent--column ">
-          <span className="txt-s txt-uppercase txt-bold">Source</span>
           <span className="wmax180 txt-break-word txt-s">
+          <strong className="txt-s txt-uppercase">Source</strong>
             {source}
             <span>
               <br />
@@ -97,12 +97,12 @@ export function Details({
           </span>
         </div>
         <div className="flex-parent flex-parent--column ">
-          <span className="txt-s txt-uppercase txt-bold">Editor</span>
           <span className="wmax180 txt-break-word txt-s">{editor}</span>
+          <strong className="txt-s txt-uppercase">Editor</strong>
         </div>
         <div className="flex-parent flex-parent--column">
-          <span className="txt-s txt-uppercase txt-bold">Imagery</span>
           <span className="wmax180 txt-break-word txt-s">
+          <strong className="txt-s txt-uppercase">Imagery</strong>
             {imagery}
             <span>
               <br />

--- a/src/components/changeset/discussions.js
+++ b/src/components/changeset/discussions.js
@@ -38,7 +38,7 @@ class Discussions extends React.PureComponent {
             >
               <div className="flex-parent flex-parent--row justify--space-between txt-s ">
                 <span>
-                  By <span className="txt-bold">{f.get('userName')}&nbsp;</span>
+                  By <strong>{f.get('userName')}&nbsp;</strong>
                 </span>
                 <span>{moment(f.get('timestamp')).fromNow()}</span>
               </div>

--- a/src/components/changeset/features.js
+++ b/src/components/changeset/features.js
@@ -37,13 +37,13 @@ const Feature = ({
         )}
       </td>
       <td>
-        <span
+        <strong
           onClick={() => selectFeature(parseInt(data.get('osm_id'), 10))}
-          className="cursor-pointer txt-bold txt-underline-on-hover mr6"
+          className="cursor-pointer txt-underline-on-hover mr6"
         >
           Map
-        </span>
-        <span className="cursor-pointer txt-bold txt-underline-on-hover">
+        </strong>
+        <strong className="cursor-pointer txt-underline-on-hover">
           <a
             target="_blank"
             href={`http://localhost:8111/load_object?objects=${data
@@ -52,7 +52,7 @@ const Feature = ({
           >
             JOSM
           </a>
-        </span>
+        </strong>
       </td>
     </tr>
   );

--- a/src/components/changeset/header.js
+++ b/src/components/changeset/header.js
@@ -54,11 +54,11 @@ class Header extends React.PureComponent {
           </div>
           <div className="flex-parent flex-parent--row justify--space-between flex-parent--wrap">
             <span className="txt-s">
-              <span className="txt-underline-on-hover pointer txt-bold">
+              <strong className="txt-underline-on-hover pointer">
                 <a dir="ltr" onClick={this.props.toggleUser}>
                   {user}
                 </a>
-              </span>
+              </strong>
               {is_whitelisted && (
                 <svg className="icon inline-block align-middle pl3 w18 h18 color-gray">
                   <use xlinkHref="#icon-star" />

--- a/src/components/changeset/tag_changes.js
+++ b/src/components/changeset/tag_changes.js
@@ -105,9 +105,9 @@ export class ChangeItem extends React.PureComponent {
           )}
           {this.tag.slice(0, last_space)}
           <span className="txt-code">{this.tag.slice(last_space)}</span>
-          <span className="bg-blue-faint color-blue-dark mx6 px6 py3 txt-s txt-bold round">
+          <strong className="bg-blue-faint color-blue-dark mx6 px6 py3 txt-s round">
             {this.value.length}
-          </span>
+          </strong>
         </span>
         <ul
           className="cmap-vlist"
@@ -115,7 +115,9 @@ export class ChangeItem extends React.PureComponent {
             display: this.state.opened ? 'block' : 'none'
           }}
         >
-          {this.value.map((id, k) => <FeatureListItem id={id} key={k} />)}
+          {this.value.map((id, k) => (
+            <FeatureListItem id={id} key={k} />
+          ))}
         </ul>
       </div>
     );

--- a/src/components/filters/wrapper.js
+++ b/src/components/filters/wrapper.js
@@ -26,7 +26,7 @@ export function Wrapper({
             </svg>
           )}
         </span>
-        <span className="txt-bold txt-truncate pointer">{display}&nbsp;</span>
+        <strong className="txt-truncate pointer">{display}&nbsp;</strong>
       </div>
       <div className="grid">
         <span className="col col--6-mxl col--6-ml col--12-mm col--12">

--- a/src/components/list/title.js
+++ b/src/components/list/title.js
@@ -6,9 +6,9 @@ export function Title({ properties, wasOpen, date }: Object) {
   return (
     <div>
       <span className="flex-parent flex-parent--row justify--space-between align-items--center">
-        <span className={'txt-m txt-bold mt3 mr6'}>
+        <strong className={'txt-m mt3 mr6'}>
           {properties.get('user') || <i>OSM User</i>}
-        </span>
+        </strong>
         <span className="txt-s mr3">&nbsp;{moment(date).fromNow()}</span>
       </span>
     </div>

--- a/src/views/edit_team.js
+++ b/src/views/edit_team.js
@@ -115,7 +115,7 @@ class EditMappingTeam extends React.PureComponent<any, propsType, any> {
               <div>
                 <div className="mt24 mb12">
                   <h2 className="pl12 txt-xl mr6 border-b border--gray-light border--1">
-                    <span className="txt-bold">Editing mapping team: </span>
+                    <strong>Editing mapping team: </strong>
                     {this.props.data.getIn(['team', 'name'])}
                   </h2>
                   <SaveButton

--- a/src/views/navbar_changeset.js
+++ b/src/views/navbar_changeset.js
@@ -162,7 +162,7 @@ class NavbarChangeset extends React.PureComponent<void, propsType, *> {
                 </Link>
               )}
               <span className="txt-l color-gray--dark">
-                <span className="txt-bold">Changeset:</span>{' '}
+                <strong>Changeset:</strong>{' '}
                 <span className="txt-underline mr12">
                   <a
                     href={`https://openstreetmap.org/changeset/${

--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -111,7 +111,7 @@ class NavbarSidebar extends React.PureComponent {
                 }}
               >
                 <span className="txt-xl">
-                  <span className="color-blue txt-bold">OSM</span>
+                  <strong className="color-blue">OSM</strong>
                   Cha
                 </span>
               </Link>

--- a/src/views/saved_filters.js
+++ b/src/views/saved_filters.js
@@ -261,7 +261,7 @@ class SavedFilters extends React.PureComponent<any, propsType, any> {
               <div>
                 <div className="mt24 mb12">
                   <h2 className="pl12 txt-xl mr6 txt-bold border-b border--gray-light border--1">
-                    <span className="txt-bold">My saved filters</span>
+                    My saved filters
                   </h2>
                   <ListFortified
                     data={this.props.data.getIn(['aoi', 'features'], List())}

--- a/src/views/teams.js
+++ b/src/views/teams.js
@@ -135,7 +135,7 @@ class SaveButton extends React.PureComponent {
             ) : (
               <div className="txt-h4 txt-bold">Add a new mapping team</div>
             )}
-            <span className="txt-bold txt-truncate pt6">Name</span>
+            <strong className="txt-truncate pt6">Name</strong>
             <input
               placeholder="New team name"
               className="input wmax180"
@@ -150,7 +150,7 @@ class SaveButton extends React.PureComponent {
               onKeyDown={this.onKeyDown}
               disabled={!this.props.userIsOwner}
             />
-            <span className="txt-bold txt-truncate pt6">Users</span>
+            <strong className="txt-truncate pt6">Users</strong>
             <textarea
               placeholder={'[{"username": "name"}, {"username": "other_user"}]'}
               className="textarea h180"

--- a/src/views/teams.js
+++ b/src/views/teams.js
@@ -357,7 +357,7 @@ class MappingTeams extends React.PureComponent<any, propsType, any> {
               <div>
                 <div className="mt24 mb12">
                   <h2 className="pl12 txt-xl mr6 txt-bold border-b border--gray-light border--1">
-                    <span className="txt-bold">My mapping teams</span>
+                    My mapping teams
                   </h2>
                   <ListFortified
                     data={this.props.data.getIn(['teams'], List())}

--- a/src/views/teams.js
+++ b/src/views/teams.js
@@ -133,8 +133,8 @@ class SaveButton extends React.PureComponent {
             {this.props.activeTeam ? (
               <span />
             ) : (
-              <div className="txt-h4 txt-bold">Add a new mapping team</div>
-            )}
+                <h3 className="txt-h4 txt-bold">Add a new mapping team</h3>
+              )}
             <strong className="txt-truncate pt6">Name</strong>
             <input
               placeholder="New team name"

--- a/src/views/user.js
+++ b/src/views/user.js
@@ -104,7 +104,7 @@ class User extends React.PureComponent<any, propsType, any> {
               <div>
                 <div className="mt24 mb12">
                   <h2 className="pl12 txt-xl mr6 txt-bold border-b border--gray-light border--1">
-                    <span className="txt-bold">Review Comments Template </span>
+                    Review Comments Template
                   </h2>
                   <EditUserDetails />
                 </div>


### PR DESCRIPTION
I was looking through the code and found quite a few places where the css class `txt-bold` was used instead of a simple strong-tag. 

IMO this makes the code harder to read. Also the strong-Tag version has less code and more semantic html.

This PR has a lot of small commits since I was battling the 'husky' precommit-stuff. Before merging, I suggest to squash it into one commit (which [should be possible from the Web UI](https://github.blog/2016-04-01-squash-your-commits/) AFAIK).
