### PR TITLE
Prepend www to openstreetmap.org hostnames

### DIFF
--- a/src/components/changeset/open_in.js
+++ b/src/components/changeset/open_in.js
@@ -23,7 +23,7 @@ export function OpenIn({ changesetId, coordinates, className }) {
           {
             label: 'OSM',
             value: 'OSM',
-            href: `https://openstreetmap.org/changeset/${changesetId}`
+            href: `https://www.openstreetmap.org/changeset/${changesetId}`
           },
 
           {

--- a/src/components/changeset/user.js
+++ b/src/components/changeset/user.js
@@ -84,7 +84,7 @@ export class User extends React.PureComponent {
                 rel="noopener noreferrer"
                 title="Open in OSM"
                 className="mx3 btn btn--s border border--1 border--darken5 border--darken25-on-hover round bg-darken10 bg-darken5-on-hover color-gray transition"
-                href={`https://openstreetmap.org/user/${this.props.userDetails.get(
+                href={`https://www.openstreetmap.org/user/${this.props.userDetails.get(
                   'name'
                 )}`}
               >

--- a/src/views/navbar_changeset.js
+++ b/src/views/navbar_changeset.js
@@ -158,7 +158,7 @@ class NavbarChangeset extends React.PureComponent<void, propsType, *> {
                 <strong>Changeset:</strong>{' '}
                 <span className="txt-underline mr12">
                   <a
-                    href={`https://openstreetmap.org/changeset/${this.props.changesetId}`}
+                    href={`https://www.openstreetmap.org/changeset/${this.props.changesetId}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     title="See on OSM"


### PR DESCRIPTION
https://openstreetmap.org HTTP 301 redirects to https://www.openstreetmap.org.

This PR directly https://uses www.openstreetmap.org to avoid a redirect. 

It also allows copying OSM changesets URL from osmcha to the File>Open Location dialog of JOSM, as it doesn't accept non-www-prefixed OSM urls.