### PR TITLE
Remove 10-character limit on the username sidebar button

### DIFF
--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -77,6 +77,7 @@ class NavbarSidebar extends React.PureComponent {
 
     return (
       <Dropdown
+        className="txt-truncate"
         display={username ? username : 'User'}
         options={[
           { label: 'Account settings', url: '/user' },

--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -77,7 +77,7 @@ class NavbarSidebar extends React.PureComponent {
 
     return (
       <Dropdown
-        display={username ? username.slice(0, 10) : 'User'}
+        display={username ? username : 'User'}
         options={[
           { label: 'Account settings', url: '/user' },
           { label: 'My saved filters', url: '/saved-filters' },

--- a/src/views/navbar_sidebar.js
+++ b/src/views/navbar_sidebar.js
@@ -77,8 +77,7 @@ class NavbarSidebar extends React.PureComponent {
 
     return (
       <Dropdown
-        className="txt-truncate"
-        display={username ? username : 'User'}
+        display={username ? <span className="wmax180 align-middle inline-block txt-truncate">{username}</span> : 'User'}
         options={[
           { label: 'Account settings', url: '/user' },
           { label: 'My saved filters', url: '/saved-filters' },


### PR DESCRIPTION
Remove the 10-character limit on the username button on the sidebar.

_Then_
![username button then](https://user-images.githubusercontent.com/4031965/121886019-43b13580-cceb-11eb-97a0-f7b5e4c3039c.png)


_Now_
![username button now](https://user-images.githubusercontent.com/4031965/121886030-46138f80-cceb-11eb-871e-a2b038bea26b.png)


