### PR TITLE
Add sanitize to DangerouslySetInnerHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "animate.css": "^3.7.2",
     "changeset-map": "^1.11.2",
     "date-fns": "^2.22.1",
+    "dompurify": "^3.0.3",
     "history": "^4.10.1",
     "immutable": "^3.8.2",
     "lodash.debounce": "^4.0.8",

--- a/src/views/about.js
+++ b/src/views/about.js
@@ -90,7 +90,8 @@ export class About extends React.PureComponent {
           id="guide"
           className="pb36 px12"
           dangerouslySetInnerHTML={{
-            __html: this.state.about
+            // eslint-disable-next-line
+            __html: sanitize(this.state.about)
           }}
         />
       </div>

--- a/src/views/about.js
+++ b/src/views/about.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react';
 import showdown from 'showdown';
+import DOMPurify from 'dompurify';
+
 import { cancelablePromise } from '../utils/promise';
 import { appVersion, isDev, isStaging, isLocal } from '../config';
 
@@ -90,8 +92,7 @@ export class About extends React.PureComponent {
           id="guide"
           className="pb36 px12"
           dangerouslySetInnerHTML={{
-            // eslint-disable-next-line
-            __html: sanitize(this.state.about)
+            __html: DOMPurify.sanitize(this.state.about)
           }}
         />
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4412,6 +4412,11 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dompurify@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.3.tgz#4b115d15a091ddc96f232bcef668550a2f6f1430"
+  integrity sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ==
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"


### PR DESCRIPTION
We received a new HackerOne report for [repo](https://github.com/mapbox/osmcha-frontend/). 
This report is about using “React’s dangerously set inner HTML.”

Recomendations: sanitize data when using dangerouslySetInnerHTML, which means changing line #93 from `__html: this.state.about` to `__html: sanitize(this.state.about)`.